### PR TITLE
Implemented getMany, removeMany and setMany

### DIFF
--- a/src/adapter.cookie.js
+++ b/src/adapter.cookie.js
@@ -1,5 +1,9 @@
 import { safeJSONParse, } from "./util.js";
-
+import {
+	setMany as sharedSetMany,
+	getMany as sharedGetMany,
+	removeMany as sharedRemoveMany,
+} from "./many.js";
 
 // ***********************
 
@@ -12,6 +16,9 @@ export {
 	remove,
 	keys,
 	entries,
+	setMany,
+	getMany,
+	removeMany,
 }
 var publicAPI = {
 	storageType,
@@ -21,6 +28,10 @@ var publicAPI = {
 	remove,
 	keys,
 	entries,
+	setMany,
+	getMany,
+	removeMany,
+
 };
 export default publicAPI;
 
@@ -105,4 +116,15 @@ function getAllCookies() {
 				))
 		)
 	);
+}
+function setMany(data) {
+	return sharedSetMany(data, set);
+}
+
+function getMany(props) {
+	return sharedGetMany(props, get);
+}
+
+function removeMany(props) {
+	return sharedRemoveMany(props, remove);
 }

--- a/src/adapter.cookie.js
+++ b/src/adapter.cookie.js
@@ -38,15 +38,15 @@ export default publicAPI;
 
 // ***********************
 
-function has(name) {
+async function has(name) {
 	return (name in getAllCookies());
 }
 
-function get(name) {
+async function get(name) {
 	return safeJSONParse(getAllCookies()[name]);
 }
 
-function set(name,value) {
+async function set(name,value) {
 	var expires = new Date();
 	var expiresSeconds = 400 * 24 * 60 * 60;	// 400 days from now (max allowed)
 	expires.setTime(expires.getTime() + (expiresSeconds * 1000));
@@ -75,7 +75,7 @@ function set(name,value) {
 	return true;
 }
 
-function remove(name) {
+async function remove(name) {
 	var expires = new Date();
 	expires.setTime(expires.getTime() - 1000);
 	document.cookie = [
@@ -90,18 +90,17 @@ function remove(name) {
 	return true;
 }
 
-function keys() {
+async function keys() {
 	return Object.keys(getAllCookies());
 }
 
-function entries() {
-	return (
-		Object.entries(getAllCookies())
-			.map(([ name, value ]) => ([
-				name,
-				safeJSONParse(value)
-			]))
-	);
+async function entries() {
+    const allCookies = await getAllCookies(); // Await the async operation.
+    const mappedEntries = Object.entries(allCookies).map(async ([name, value]) => [
+        name,
+        await safeJSONParse(value), // Await the async parsing.
+    ]);
+    return Promise.all(mappedEntries); // Ensure all async tasks resolve.
 }
 
 function getAllCookies() {
@@ -117,14 +116,14 @@ function getAllCookies() {
 		)
 	);
 }
-function setMany(data) {
+async function setMany(data) {
 	return sharedSetMany(data, set);
 }
 
-function getMany(props) {
+async function getMany(props) {
 	return sharedGetMany(props, get);
 }
 
-function removeMany(props) {
+async function removeMany(props) {
 	return sharedRemoveMany(props, remove);
 }

--- a/src/adapter.idb.js
+++ b/src/adapter.idb.js
@@ -5,7 +5,11 @@ import {
 	keys as idbKeys,
 	entries as idbEntries,
 } from "idb-keyval";
-
+import {
+	setMany as sharedSetMany,
+	getMany as sharedGetMany,
+	removeMany as sharedRemoveMany,
+} from "./many.js";
 
 // ***********************
 
@@ -18,6 +22,9 @@ export {
 	remove,
 	idbKeys as keys,
 	idbEntries as entries,
+	setMany,
+	getMany,
+	removeMany,
 }
 var publicAPI = {
 	storageType,
@@ -27,6 +34,9 @@ var publicAPI = {
 	remove,
 	keys: idbKeys,
 	entries: idbEntries,
+	setMany,
+	getMany,
+	removeMany,
 };
 export default publicAPI;
 
@@ -63,4 +73,16 @@ async function set(name,value) {
 async function remove(name) {
 	await idbDel(name);
 	return true;
+}
+
+async function setMany(data) {
+	return sharedSetMany(data, set);
+}
+
+async function getMany(props) {
+	return sharedGetMany(props, get);
+}
+
+async function removeMany(props) {
+	return sharedRemoveMany(props, remove);
 }

--- a/src/adapter.local-storage.js
+++ b/src/adapter.local-storage.js
@@ -36,11 +36,8 @@ export default publicAPI;
 
 // ***********************
 
-// function has(name) {
-// 	// note: https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem#return_value
-// 	return (window.localStorage.getItem(name) !== null);
-// }
 async function has(name) {
+	// note: https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem#return_value
 	return (window.localStorage.getItem(name) !== null);
 }
 

--- a/src/adapter.local-storage.js
+++ b/src/adapter.local-storage.js
@@ -36,16 +36,19 @@ export default publicAPI;
 
 // ***********************
 
-function has(name) {
-	// note: https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem#return_value
+// function has(name) {
+// 	// note: https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem#return_value
+// 	return (window.localStorage.getItem(name) !== null);
+// }
+async function has(name) {
 	return (window.localStorage.getItem(name) !== null);
 }
 
-function get(name) {
+async function get(name) {
 	return safeJSONParse(window.localStorage.getItem(name));
 }
 
-function set(name,value) {
+async function set(name,value) {
 	try {
 		window.localStorage.setItem(
 			name,
@@ -63,12 +66,12 @@ function set(name,value) {
 	}
 }
 
-function remove(name) {
+async function remove(name) {
 	window.localStorage.removeItem(name);
 	return true;
 }
 
-function keys() {
+async function keys() {
 	var storeKeys = [];
 	for (let i = 0; i < window.localStorage.length; i++) {
 		storeKeys.push(window.localStorage.key(i));
@@ -76,7 +79,7 @@ function keys() {
 	return storeKeys;
 }
 
-function entries() {
+async function entries() {
 	var storeEntries = [];
 	for (let i = 0; i < window.localStorage.length; i++) {
 		let name = window.localStorage.key(i);
@@ -88,14 +91,14 @@ function entries() {
 	return storeEntries;
 }
 
-function setMany(data) {
+async function setMany(data) {
 	return sharedSetMany(data, set);
 }
 
-function getMany(props) {
+async function getMany(props) {
 	return sharedGetMany(props, get);
 }
 
-function removeMany(props) {
+async function removeMany(props) {
 	return sharedRemoveMany(props, remove);
 }

--- a/src/adapter.local-storage.js
+++ b/src/adapter.local-storage.js
@@ -1,5 +1,9 @@
-import { safeJSONParse, } from "./util.js";
-
+import { safeJSONParse } from "./util.js";
+import {
+	setMany as sharedSetMany,
+	getMany as sharedGetMany,
+	removeMany as sharedRemoveMany,
+} from "./many.js";
 
 // ***********************
 
@@ -12,7 +16,10 @@ export {
 	remove,
 	keys,
 	entries,
-}
+	setMany,
+	getMany,
+	removeMany,
+};
 var publicAPI = {
 	storageType,
 	has,
@@ -21,9 +28,11 @@ var publicAPI = {
 	remove,
 	keys,
 	entries,
+	setMany,
+	getMany,
+	removeMany,
 };
 export default publicAPI;
-
 
 // ***********************
 
@@ -77,4 +86,16 @@ function entries() {
 		]);
 	}
 	return storeEntries;
+}
+
+function setMany(data) {
+	return sharedSetMany(data, set);
+}
+
+function getMany(props) {
+	return sharedGetMany(props, get);
+}
+
+function removeMany(props) {
+	return sharedRemoveMany(props, remove);
 }

--- a/src/adapter.session-storage.js
+++ b/src/adapter.session-storage.js
@@ -37,16 +37,16 @@ export default publicAPI;
 
 // ***********************
 
-function has(name) {
+async function has(name) {
 	// note: https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem#return_value
 	return (window.sessionStorage.getItem(name) !== null);
 }
 
-function get(name) {
+async function get(name) {
 	return safeJSONParse(window.sessionStorage.getItem(name));
 }
 
-function set(name,value) {
+async function set(name,value) {
 	try {
 		window.sessionStorage.setItem(
 			name,
@@ -64,12 +64,12 @@ function set(name,value) {
 	}
 }
 
-function remove(name) {
+async function remove(name) {
 	window.sessionStorage.removeItem(name);
 	return true;
 }
 
-function keys() {
+async function keys() {
 	var storeKeys = [];
 	for (let i = 0; i < window.sessionStorage.length; i++) {
 		storeKeys.push(window.sessionStorage.key(i));
@@ -77,7 +77,7 @@ function keys() {
 	return storeKeys;
 }
 
-function entries() {
+async function entries() {
 	var storeEntries = [];
 	for (let i = 0; i < window.sessionStorage.length; i++) {
 		let name = window.sessionStorage.key(i);
@@ -88,14 +88,14 @@ function entries() {
 	}
 	return storeEntries;
 }
-function setMany(data) {
+async function setMany(data) {
 	return sharedSetMany(data, set);
 }
 
-function getMany(props) {
+async function getMany(props) {
 	return sharedGetMany(props, get);
 }
 
-function removeMany(props) {
+async function removeMany(props) {
 	return sharedRemoveMany(props, remove);
 }

--- a/src/adapter.session-storage.js
+++ b/src/adapter.session-storage.js
@@ -1,5 +1,9 @@
 import { safeJSONParse, } from "./util.js";
-
+import {
+	setMany as sharedSetMany,
+	getMany as sharedGetMany,
+	removeMany as sharedRemoveMany,
+} from "./many.js";
 
 // ***********************
 
@@ -12,6 +16,9 @@ export {
 	remove,
 	keys,
 	entries,
+	setMany,
+	getMany,
+	removeMany,
 }
 var publicAPI = {
 	storageType,
@@ -21,6 +28,9 @@ var publicAPI = {
 	remove,
 	keys,
 	entries,
+	setMany,
+	getMany,
+	removeMany,
 };
 export default publicAPI;
 
@@ -77,4 +87,15 @@ function entries() {
 		]);
 	}
 	return storeEntries;
+}
+function setMany(data) {
+	return sharedSetMany(data, set);
+}
+
+function getMany(props) {
+	return sharedGetMany(props, get);
+}
+
+function removeMany(props) {
+	return sharedRemoveMany(props, remove);
 }

--- a/src/many.js
+++ b/src/many.js
@@ -1,0 +1,12 @@
+export async function  setMany(data, set) {
+	if (data != null && typeof data == "object" && !Array.isArray(data)) {
+		data = [...Object.entries(data)];
+	}
+	return Promise.all(data.map(([prop, val]) => set(prop, val))).then(() => true).catch(() => false);
+}
+export async function getMany(props, get) {
+	return await Promise.all(props.map((prop) => get(prop)));
+}
+export async function removeMany(props, remove) {
+	return await Promise.all(props.map((prop) => remove(prop))).then(() => true).catch(() => false);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,7 @@ async function runTests() {
 		[ "idb", "remove", true ],
 		[ "idb", "keys(2)", [ "meaning", ], ],
 		[ "idb", "setMany", true],
+		[ "idb", "getMany", [ "world", { ofLife: 42, }, ], ],
 		[ "idb", "removeMany", true],
 		[ "local-storage", "has(1)", false ],
 		[ "local-storage", "get(1)", null ],
@@ -77,6 +78,7 @@ async function runTests() {
 		[ "local-storage", "remove", true ],
 		[ "local-storage", "keys(2)", [ "meaning", ], ],
 		[ "local-storage", "setMany", true],
+		[ "local-storage", "getMany", [ "world", { ofLife: 42, }, ], ],
 		[ "local-storage", "removeMany", true],
 		[ "session-storage", "has(1)", false ],
 		[ "session-storage", "get(1)", null ],
@@ -89,6 +91,7 @@ async function runTests() {
 		[ "session-storage", "remove", true ],
 		[ "session-storage", "keys(2)", [ "meaning", ], ],
 		[ "session-storage", "setMany", true],
+		[ "session-storage", "getMany", [ "world", { ofLife: 42, }, ], ],
 		[ "session-storage", "removeMany", true],
 		[ "cookie", "has(1)", false ],
 		[ "cookie", "get(1)", null ],
@@ -101,6 +104,7 @@ async function runTests() {
 		[ "cookie", "remove", true ],
 		[ "cookie", "keys(2)", [ "meaning", ], ],
 		[ "cookie", "setMany", true],
+		[ "cookie", "getMany", [ "world", { ofLife: 42, }, ], ],
 		[ "cookie", "removeMany", true],
 		[ "opfs", "has(1)", false ],
 		[ "opfs", "get(1)", null ],
@@ -141,6 +145,7 @@ async function runTests() {
 		testResults.push([ storageTypes[store.storageType][0], "keys(2)", sortKeys(filterKnownNames("hello","meaning")(await store.keys())), ]);
 		if(!store.storageType.includes("opfs")) {
 			testResults.push([ storageTypes[store.storageType][0], "setMany", await store.setMany([ [ "hello", "world", ], [ "meaning", { ofLife: 42, }, ], ]), ]);
+			testResults.push([ storageTypes[store.storageType][0], "getMany", await store.getMany([ "hello", "meaning", ]), ]);
 			testResults.push([ storageTypes[store.storageType][0], "removeMany", await store.removeMany([ "hello", "meaning", ]), ]);
 		}
 		await store.remove("meaning");

--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,8 @@ async function runTests() {
 		[ "idb", "entries", [ [ "hello", "world", ], [ "meaning", { ofLife: 42, }, ], ], ],
 		[ "idb", "remove", true ],
 		[ "idb", "keys(2)", [ "meaning", ], ],
+		[ "idb", "setMany", true],
+		[ "idb", "removeMany", true],
 		[ "local-storage", "has(1)", false ],
 		[ "local-storage", "get(1)", null ],
 		[ "local-storage", "set(1)", true ],
@@ -74,6 +76,8 @@ async function runTests() {
 		[ "local-storage", "entries", [ [ "hello", "world", ], [ "meaning", { ofLife: 42, }, ], ], ],
 		[ "local-storage", "remove", true ],
 		[ "local-storage", "keys(2)", [ "meaning", ], ],
+		[ "local-storage", "setMany", true],
+		[ "local-storage", "removeMany", true],
 		[ "session-storage", "has(1)", false ],
 		[ "session-storage", "get(1)", null ],
 		[ "session-storage", "set(1)", true ],
@@ -84,6 +88,8 @@ async function runTests() {
 		[ "session-storage", "entries", [ [ "hello", "world", ], [ "meaning", { ofLife: 42, }, ], ], ],
 		[ "session-storage", "remove", true ],
 		[ "session-storage", "keys(2)", [ "meaning", ], ],
+		[ "session-storage", "setMany", true],
+		[ "session-storage", "removeMany", true],
 		[ "cookie", "has(1)", false ],
 		[ "cookie", "get(1)", null ],
 		[ "cookie", "set(1)", true ],
@@ -94,6 +100,8 @@ async function runTests() {
 		[ "cookie", "entries", [ [ "hello", "world", ], [ "meaning", { ofLife: 42, }, ], ], ],
 		[ "cookie", "remove", true ],
 		[ "cookie", "keys(2)", [ "meaning", ], ],
+		[ "cookie", "setMany", true],
+		[ "cookie", "removeMany", true],
 		[ "opfs", "has(1)", false ],
 		[ "opfs", "get(1)", null ],
 		[ "opfs", "set(1)", true ],
@@ -131,6 +139,10 @@ async function runTests() {
 		testResults.push([ storageTypes[store.storageType][0], "entries", sortKeys(filterKnownNames("hello","meaning")(await store.entries())), ]);
 		testResults.push([ storageTypes[store.storageType][0], "remove", await store.remove("hello"), ]);
 		testResults.push([ storageTypes[store.storageType][0], "keys(2)", sortKeys(filterKnownNames("hello","meaning")(await store.keys())), ]);
+		if(!store.storageType.includes("opfs")) {
+			testResults.push([ storageTypes[store.storageType][0], "setMany", await store.setMany([ [ "hello", "world", ], [ "meaning", { ofLife: 42, }, ], ]), ]);
+			testResults.push([ storageTypes[store.storageType][0], "removeMany", await store.removeMany([ "hello", "meaning", ]), ]);
+		}
 		await store.remove("meaning");
 	}
 	var testsPassed = true;


### PR DESCRIPTION
## Created Methods for getMany, setMany and removeMany #5 

Local storage, Session storage, Idb and Cookie adapter supports these methods.

```
setMany([
     { 'name': 'Alizey'},
     { 'person': {name:'Joe',age:20}},
     {'num':[1,2,3] },
     [ 'prop1', 'val1' ], 
     [ 'prop2', 'val2' ]])   // return true
getMany(['name', 'person', 'num','prop1','prop2']) // returns ["Alizey", {name:'Joe',age:20}, [1, 2, 3],'val1','val2']
removeMany(['name', 'person', 'num','prop1','prop2']) // returns true
```
All methods receives array of objects i.e key value pairs, keys must be array and values can be a string, array, objects, and tuples
Note: OPFS adapter has not been included in this PR.

